### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pnpm-fix.yml
+++ b/.github/workflows/pnpm-fix.yml
@@ -1,4 +1,6 @@
 name: Fix pnpm lock conflicts
+permissions:
+  contents: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Zurihaqi/Zurihaqi.github.io/security/code-scanning/2](https://github.com/Zurihaqi/Zurihaqi.github.io/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow. Since the job is updating and pushing changes to the repository, it requires `contents: write` at a minimum (for pushing commits). The best approach is to add the `permissions:` key at the root of the workflow, applying to all jobs, unless finer control is required. In this case, a root-level `permissions:` declaration is both minimal and sufficient. Edit `.github/workflows/pnpm-fix.yml` and insert after the workflow `name:` (between line 1 and 3), as shown below. This explicit permissions block will adhere to best practice and address the CodeQL alert.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
